### PR TITLE
Read packager options from params.ini file in silent mode

### DIFF
--- a/Packager/params.ini
+++ b/Packager/params.ini
@@ -1,0 +1,11 @@
+################################################################################
+# Customization parameters for Packager fields
+################################################################################
+
+[Variables]
+AgentSourceBinaryPath='C:\path\to\OCS-Windows-Agent-Setup-x64.exe'
+OcsPluginsFiles='C:\path\to\OcsPlugins\*'
+CACertificateFilePath='C:\path\to\cacert.crt'
+DestinationFolder='C:\path\to\DestinationFolder'
+CmdLineOptions="/S /NOSPLASH /SERVER=http://server/ocsinventory /SSL=1 /CA=cacert.crt /NOW"
+Label=""

--- a/Packager/params.ini
+++ b/Packager/params.ini
@@ -9,3 +9,5 @@ CACertificateFilePath='C:\path\to\cacert.crt'
 DestinationFolder='C:\path\to\DestinationFolder'
 CmdLineOptions="/S /NOSPLASH /SERVER=http://server/ocsinventory /SSL=1 /CA=cacert.crt /NOW"
 Label=""
+PsExecAdminId=""
+PsExecAdminPwd=""


### PR DESCRIPTION
Based on a first revision of @adubois-dev : 

Packager options are stored inside a params.ini file and will be used if the packager is launched with /S (silent mode)